### PR TITLE
Use PyPi organization secret instead of repository secret

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,6 +38,6 @@ jobs:
 
     - name: Release to PyPI
       env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USER }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
       run: twine upload --verbose dist/* || echo 'Version exists'


### PR DESCRIPTION
Use organization secret PyPi credentials so we can manage these credentials centrally and scope credential permissions to upload packages only.